### PR TITLE
feat: enhance login page with validation

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,31 +1,70 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="th">
 <head>
 <meta charset="UTF-8">
-<title>Login</title>
+<title>เข้าสู่ระบบ</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body class="thai-pattern">
+<div class="login-container fade-in">
+  <h1>เข้าสู่ระบบ</h1>
+  <form id="loginForm" onsubmit="login(event)" class="login-form">
+    <input id="email" type="text" placeholder="อีเมลหรือชื่อผู้ใช้" class="input-field" required>
+    <span id="emailError" class="error hidden">รูปแบบอีเมลไม่ถูกต้อง</span>
+    <input id="password" type="password" placeholder="รหัสผ่าน" class="input-field" required>
+    <label class="remember"><input type="checkbox" id="remember"> จำฉันไว้</label>
+    <button type="submit" class="btn-primary">เข้าสู่ระบบ</button>
+  </form>
+  <a href="#" class="forgot-link">ลืมรหัสผ่าน?</a>
+  <div class="sso-buttons">
+    <button class="btn-sso-google">Google</button>
+    <button class="btn-sso-apple">Apple</button>
+    <button class="btn-sso-github">GitHub</button>
+  </div>
+  <p><a href="register.html">ลงทะเบียน</a></p>
+</div>
+<div id="toast" class="toast hidden"></div>
 <script>
 async function login(event){
   event.preventDefault();
-  const username=document.getElementById('username').value;
+  const username=document.getElementById('email').value.trim();
   const password=document.getElementById('password').value;
+  const remember=document.getElementById('remember').checked;
   const res=await fetch('/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username,password})});
   const data=await res.json();
   if(res.ok){
-    localStorage.setItem('token',data.token);
-    window.location.href='dashboard.html';
+    if(remember){
+      localStorage.setItem('token',data.token);
+    }else{
+      sessionStorage.setItem('token',data.token);
+    }
+    const ref=document.referrer && document.referrer!==window.location.href?document.referrer:'dashboard.html';
+    window.location.href=ref;
   }else{
-    alert(data.error||'Login failed');
+    showToast(data.error||'เข้าสู่ระบบไม่สำเร็จ');
   }
 }
+
+function showToast(msg){
+  const toast=document.getElementById('toast');
+  toast.textContent=msg;
+  toast.classList.remove('hidden');
+  setTimeout(()=>toast.classList.add('hidden'),3000);
+}
+
+const emailInput=document.getElementById('email');
+const emailError=document.getElementById('emailError');
+emailInput.addEventListener('input',()=>{
+  const value=emailInput.value.trim();
+  const isEmail=value.includes('@');
+  const valid=/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  if(isEmail && !valid){
+    emailError.classList.remove('hidden');
+  }else{
+    emailError.classList.add('hidden');
+  }
+});
 </script>
-</head>
-<body>
-<h1>Login</h1>
-<form onsubmit="login(event)">
-<input id="username" placeholder="Username" required>
-<input id="password" type="password" placeholder="Password" required>
-<button type="submit">Login</button>
-</form>
-<p><a href="register.html">Register</a></p>
 </body>
 </html>
+

--- a/style.css
+++ b/style.css
@@ -41,3 +41,94 @@ body { font-family: 'Sarabun', sans-serif; }
     background: linear-gradient(135deg, #FFF7ED 0%, #FFFBEB 100%);
     border: 2px solid #F59E0B;
 }
+
+.login-container {
+    max-width: 400px;
+    margin: 100px auto;
+    padding: 2rem;
+    background-color: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}
+
+.login-form {
+    display: flex;
+    flex-direction: column;
+}
+
+.input-field {
+    width: 100%;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 0.375rem;
+}
+
+.btn-primary {
+    background-color: #DC143C;
+    color: #fff;
+    width: 100%;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+}
+
+.btn-primary:hover {
+    background-color: #b10d30;
+}
+
+.forgot-link {
+    display: block;
+    margin-top: 0.5rem;
+    text-align: right;
+    color: #DC143C;
+}
+
+.remember {
+    display: flex;
+    align-items: center;
+    margin: 0.5rem 0;
+    font-size: 0.875rem;
+}
+
+.remember input {
+    margin-right: 0.5rem;
+}
+
+.sso-buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1rem;
+}
+
+.sso-buttons button {
+    flex: 1;
+    margin: 0 0.25rem;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 0.375rem;
+    color: #fff;
+    cursor: pointer;
+}
+
+.btn-sso-google { background-color: #4285F4; }
+.btn-sso-apple { background-color: #000; }
+.btn-sso-github { background-color: #333; }
+
+.error {
+    color: #DC143C;
+    font-size: 0.875rem;
+}
+
+.toast {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background-color: #DC143C;
+    color: #fff;
+    padding: 0.75rem 1rem;
+    border-radius: 0.375rem;
+}
+
+.hidden { display: none; }


### PR DESCRIPTION
## Summary
- add email/username field, remember-me, SSO buttons, and Thai-styled layout
- validate email with instant feedback and show toast on login failure
- redirect to previous page after successful login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a543f828832f970936d7a40bb077